### PR TITLE
Remove the use of depcreated .hover() method

### DIFF
--- a/js/jquery.overlayScrollbars.js
+++ b/js/jquery.overlayScrollbars.js
@@ -3313,12 +3313,12 @@
                             compatibility.prvD(event);
                             compatibility.stpP(event);
                         }
-                    }).hover(function() { //make sure both scrollbars will stay visible if one scrollbar is hovered if autoHide is "scroll".
+                    }).on('mouseenter', function() { //make sure both scrollbars will stay visible if one scrollbar is hovered if autoHide is "scroll".
                         if (_scrollbarsAutoHideScroll || _scrollbarsAutoHideMove) {
                             _scrollbarsAutoHideFlagScrollAndHovered = true;
                             refreshScrollbarsAutoHide(true);
                         }
-                    }, function() {
+                    }).on('mouseleave', function() {
                         if (_scrollbarsAutoHideScroll || _scrollbarsAutoHideMove) {
                             _scrollbarsAutoHideFlagScrollAndHovered = false;
                             refreshScrollbarsAutoHide(false);


### PR DESCRIPTION
Fix #66 by removing the use of deprecated `.hover()` method