### PR TITLE
Fix issue with non-supporting ES6 browsers (e.g. IE11) and webpack

### DIFF
--- a/packages/overlayscrollbars-ngx/package.json
+++ b/packages/overlayscrollbars-ngx/package.json
@@ -19,6 +19,7 @@
     "bugs": {
         "url": "https://github.com/KingSora/OverlayScrollbars/issues"
     },
+    "browser": "./dist/overlayscrollbars-ngx.js",
     "main": "./dist/overlayscrollbars-ngx.js",
     "module": "./dist/overlayscrollbars-ngx.esm.js",
     "typings": "./dist/types/index.d.ts",

--- a/packages/overlayscrollbars-react/package.json
+++ b/packages/overlayscrollbars-react/package.json
@@ -18,6 +18,7 @@
     "bugs": {
         "url": "https://github.com/KingSora/OverlayScrollbars/issues"
     },
+    "browser": "./dist/overlayscrollbars-react.js",
     "main": "./dist/overlayscrollbars-react.js",
     "module": "./dist/overlayscrollbars-react.esm.js",
     "typings": "./dist/types/index.d.ts",

--- a/packages/overlayscrollbars-vue/package.json
+++ b/packages/overlayscrollbars-vue/package.json
@@ -18,6 +18,7 @@
     "bugs": {
         "url": "https://github.com/KingSora/OverlayScrollbars/issues"
     },
+    "browser": "./dist/overlayscrollbars-vue.js",
     "main": "./dist/overlayscrollbars-vue.js",
     "module": "./dist/overlayscrollbars-vue.esm.js",
     "typings": "./dist/types/index.d.ts",


### PR DESCRIPTION
I tried to use your library in one of my project (using Webpack and targetting ES5) and I noticed that using it resulted in a syntax error in IE11.
After investigating about this issue, I found the root cause is that the javascript file being used in the end is **overlayscrollbars-react.esm.js** which is using ES6 syntax. This esm build should not be used in this situation.

This choice is being made by Webpack because it is picking [conditional exports](https://nodejs.org/api/esm.html#esm_dual_commonjs_es_module_packages) from the package.json file in this priority order: browser, module, main. As your package.json isn't specifying any browser conditional export, the module is picked and the esm build file is imported instead of the ES5 compliant one **overlayscrollbars-react.js** in my case.

Here are some external discussions regarding this issue happening for other libraries:
https://github.com/webpack/webpack/issues/5756#issuecomment-504919312
https://github.com/kenwheeler/cash/pull/291

Useful information regarding regarding the browser property: https://docs.npmjs.com/files/package.json#browser

I was able to handle this issue on my side by file by specifying the [resolve.mainFields](https://webpack.js.org/configuration/resolve/#resolvemainfields) property inside the webpack.config.js but this can cause [other dependencies to break](https://github.com/webpack/webpack/issues/5756#issuecomment-405468106) and can be fixed easily on your side with this PR.

Note: I did the same change for ngx and vue as the issue would be the same.
