### PR TITLE
Support React 17 with peer dependencies

### DIFF
--- a/packages/overlayscrollbars-react/package.json
+++ b/packages/overlayscrollbars-react/package.json
@@ -39,7 +39,7 @@
         "typescript": "^3.8.3"
     },
     "peerDependencies": {
-        "react": "^16.4.0",
+        "react": "^16.4.0 || ^17.0.0",
         "overlayscrollbars": "^1.10.0"
     },
     "scripts": {


### PR DESCRIPTION
Update the peer dependency version for `overlayscrollbars-react` package to support React 17

Fixes #350 