### PR TITLE
Return early if arr is undefined in inArray

### DIFF
--- a/js/OverlayScrollbars.js
+++ b/js/OverlayScrollbars.js
@@ -620,6 +620,7 @@
             };
 
             function inArray(item, arr, fromIndex) {
+                if (!arr) return -1;
                 for (var i = fromIndex || 0; i < arr[LEXICON.l]; i++)
                     if (arr[i] === item)
                         return i;


### PR DESCRIPTION
In v1.13.2, I have the following issue in my app.
This has caused Cypress E2E to fail and I am having trouble.

```
OverlayScrollbars.js:623 Uncaught TypeError: Cannot read properties of undefined (reading 'length')
    at Function.inArray (OverlayScrollbars.js:623:50)
    at HTMLImageElement.updateOnLoadCallback (OverlayScrollbars.js:2817:43)
```

I added early return because `arr` was sometimes undefined in `inArray`.
