### PR TITLE
fix(react): duplicated mount because of changing tree structure

### DIFF
--- a/packages/overlayscrollbars-react/src/OverlayScrollbarsComponent.tsx
+++ b/packages/overlayscrollbars-react/src/OverlayScrollbarsComponent.tsx
@@ -77,7 +77,7 @@ const OverlayScrollbarsComponent = <T extends keyof JSX.IntrinsicElements>(
           {children}
         </div>
       ) : (
-        children
+        <div>{children}</div>
       )}
     </Tag>
   );


### PR DESCRIPTION
fixes #565 (?)

I'm not sure why that `div` was missing initially, but this change seems to fix the duplicated mount.