### PR TITLE
Fix click scrolling on pen input devices issue

### DIFF
--- a/packages/overlayscrollbars/src/setups/scrollbarsSetup/scrollbarsSetup.events.ts
+++ b/packages/overlayscrollbars/src/setups/scrollbarsSetup/scrollbarsSetup.events.ts
@@ -81,7 +81,7 @@ export const createScrollbarsSetupEvents = (
       event.propertyName.indexOf(widthHeightKey) > -1;
 
     const createInteractiveScrollEvents = () => {
-      const releasePointerCaptureEvents = 'pointerup pointerleave pointercancel lostpointercapture';
+      const releasePointerCaptureEvents = 'pointerup pointercancel lostpointercapture';
 
       const createRelativeHandleMove =
         (mouseDownScroll: number, invertedScale: number) => (deltaMovement: number) => {


### PR DESCRIPTION
Fixes https://github.com/KingSora/OverlayScrollbars/issues/630 

Chromium browsers seem to handle pointer events / touch events differently than other browsers.

With a pen input device such as a wacom pad or meta quest, a `pointerleave` event is fired on the `track` element while the pointer is still down (doesn't happen for mouse) This caused the click scroll to be aborted.

It's still unclear why a 'pointerleave' event is fired on the track element for pens on chromium, but simply not handling `pointerleave` events fixes the click scrolling issue on pens. We believe this is s relatively safe change but intend to test thorougly.