### PR TITLE
CSP Nonce

### DIFF
--- a/packages/overlayscrollbars/src/support/dom/manipulation.ts
+++ b/packages/overlayscrollbars/src/support/dom/manipulation.ts
@@ -58,6 +58,16 @@ const before = (
       }
     }
 
+    [].forEach.call(fragment.childNodes, function(child: HTMLElement) {
+      if((child.nodeType == Node.ELEMENT_NODE) && (child.tagName == 'STYLE')){
+        if(typeof child.nonce !== 'undefined'){
+          if(child.nonce.length == 0) {
+            child.nonce=document.scripts[0].nonce;
+          }
+        }
+      }
+    });
+  
     parentElm.insertBefore(fragment, anchor || null);
     return () => removeElements(insertedElms);
   }


### PR DESCRIPTION
This modification allow usage when CSP Nonce is set (same nonce on script and style).
The Content-Security-Policy headers are as follow:

-  script-src 'self' 'nonce-[foo-bar]' 'strict-dynamic';
-  style-src 'self' 'nonce-[foo-bar]';

The code uses the nonce from first document loaded script (can be the OverlayScrollbars source or other), as allowed by javascript CSP specification [Nonce](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce)
I now can use OverlayScrollbars with more restrictive CSP. No need for unsafe-inline.

Without patch:

![image](https://github.com/KingSora/OverlayScrollbars/assets/5883720/a4e8e8ea-8f4c-4f32-8566-551492961c25)

With patch:

![image](https://github.com/KingSora/OverlayScrollbars/assets/5883720/27967ae4-5966-41a1-b035-40547d346240)

Thank you!