### PR TITLE
Mistyped inline code block in Goals & Features — README.mdx

### DIFF
--- a/website/mdx/README.mdx
+++ b/website/mdx/README.mdx
@@ -16,7 +16,7 @@ I created this plugin because I hate ugly and space-consuming scrollbars. Simila
  - Flow independent - supports all values for `direction`, `flex-direction` and `writing-mode`.
  - Supports scroll snapping
  - Supports all **virtual scrolling** libraries
- - Supports the `body' element
+ - Supports the `body` element
  - Easy and effective scrollbar styling
  - Highly customizable
  - TypeScript support - completely written in TypeScript


### PR DESCRIPTION
Changed \`body' to `body`