### PR TITLE
feat: re-measure overflow without forced .update(true)

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,13 +905,14 @@ const osInstance = OverlayScrollbars(document.body, {});
   | name | `string` | The event name. |
   | listeners | `Function[]` | The functions to be removed. |
 
-  ### `update(force?): boolean`
+  ### `update(forceOrRequest?): boolean`
 
-  Updates the instance.
+  Updates the instance. When a boolean is passed it indicates the `force` option below. When an object is passed you can use the following properties:
 
-  | parameter | type | description |
+  | property | type | description |
   | :--- | :--- | :--- |
   | force | `boolean \| undefined` |  Whether the update should force the cache to be invalidated. |
+  | measureOverflow | `boolean \| undefined` |  Whether only overflow measurements should be force-updated, skipping expensive operations. |
 
   | returns | description |
   | :--- | :--- |
@@ -949,6 +950,11 @@ const osInstance = OverlayScrollbars(document.body, {});
 
   ```ts
   // A simplified version of the OverlayScrollbars TypeScript interface.
+  interface UpdateRequest {
+    force?: boolean;
+    measureOverflow?: boolean;
+  }
+
   interface OverlayScrollbars {
     // Get the current options of the instance.
     options(): Options;
@@ -968,7 +974,7 @@ const osInstance = OverlayScrollbars(document.body, {});
     off<N extends keyof EventListenerArgs>(name: N, listener: EventListener<N>[]): void;
 
     // Updates the instance.
-    update(force?: boolean): boolean;
+    update(forceOrRequest?: boolean | UpdateRequest): boolean;
 
     // Gets the instance's state.
     state(): State;

--- a/packages/overlayscrollbars/README.md
+++ b/packages/overlayscrollbars/README.md
@@ -905,13 +905,20 @@ const osInstance = OverlayScrollbars(document.body, {});
   | name | `string` | The event name. |
   | listeners | `Function[]` | The functions to be removed. |
 
-  ### `update(force?): boolean`
+  ### `update(forceOrRequest?): boolean`
 
   Updates the instance.
 
   | parameter | type | description |
   | :--- | :--- | :--- |
+  | forceOrRequest | `boolean \| UpdateRequest \| undefined` |  Either a boolean indicating the `force` option below or an object below. |
+
+  When an object is passed you can use the following properties:
+
+  | property | type | description |
+  | :--- | :--- | :--- |
   | force | `boolean \| undefined` |  Whether the update should force the cache to be invalidated. |
+  | measureOverflow | `boolean \| undefined` |  Whether only overflow measurements should be force-updated, skipping expensive operations. |
 
   | returns | description |
   | :--- | :--- |
@@ -949,6 +956,11 @@ const osInstance = OverlayScrollbars(document.body, {});
 
   ```ts
   // A simplified version of the OverlayScrollbars TypeScript interface.
+  interface UpdateRequest {
+    force?: boolean;
+    measureOverflow?: boolean;
+  }
+
   interface OverlayScrollbars {
     // Get the current options of the instance.
     options(): Options;
@@ -968,7 +980,7 @@ const osInstance = OverlayScrollbars(document.body, {});
     off<N extends keyof EventListenerArgs>(name: N, listener: EventListener<N>[]): void;
 
     // Updates the instance.
-    update(force?: boolean): boolean;
+    update(forceOrRequest?: boolean | UpdateRequest): boolean;
 
     // Gets the instance's state.
     state(): State;

--- a/packages/overlayscrollbars/src/overlayscrollbars.ts
+++ b/packages/overlayscrollbars/src/overlayscrollbars.ts
@@ -296,11 +296,11 @@ export interface OverlayScrollbars {
 
   /**
    * Updates the instance.
-   * @param force Whether the update should force the cache to be invalidated.
+   * @param forceOrRequest Pass a boolean to force the caches to be invalidated, or an options object.
    * @returns A boolean which indicates whether the `update` event was triggered through this update.
    * The update event is only triggered if something changed because of this update.
    */
-  update(force?: boolean): boolean;
+  update(forceOrRequest?: boolean | UpdateRequest): boolean;
   /** Returns the state of the instance. */
   state(): State;
   /** Returns the elements of the instance. */
@@ -310,6 +310,13 @@ export interface OverlayScrollbars {
   /** Returns the instance of the passed plugin or `undefined` if no instance was found. */
   plugin<P extends InstancePlugin>(osPlugin: P): InferInstancePluginModuleInstance<P> | undefined;
 }
+
+export type UpdateRequest = {
+  /** Force the caches to be invalidated. */
+  force?: boolean;
+  /** Only overflow measurements should be refreshed. */
+  measureOverflow?: boolean;
+};
 
 export const OverlayScrollbars: OverlayScrollbarsStatic = (
   target: InitializationTarget,
@@ -504,7 +511,11 @@ export const OverlayScrollbars: OverlayScrollbarsStatic = (
           }
         );
       },
-      update: (_force?: boolean) => setupsUpdate({ _force, _takeRecords: true }),
+      update: (forceOrRequest?: boolean | UpdateRequest) => setupsUpdate({
+        _force: typeof forceOrRequest === 'object' ? forceOrRequest?.force : forceOrRequest,
+        _measureOverflow: typeof forceOrRequest === 'object' ? forceOrRequest.measureOverflow : false,
+        _takeRecords: true
+      }),
       destroy: bind(destroy, false),
       plugin: <P extends InstancePlugin>(plugin: P) =>
         instancePluginModuleInstances[keys(plugin)[0]] as

--- a/packages/overlayscrollbars/src/setups/setups.ts
+++ b/packages/overlayscrollbars/src/setups/setups.ts
@@ -50,6 +50,8 @@ export interface SetupsUpdateInfo {
   _takeRecords?: boolean;
   /** Whether one or more scrollbars has been cloned. */
   _cloneScrollbar?: boolean;
+  /** Whether only overflow measurements should be refreshed. */
+  _measureOverflow?: boolean;
 }
 
 export interface SetupsUpdateHints {
@@ -69,7 +71,7 @@ export interface SetupsElements {
 
 export type Setups = [
   construct: () => () => void,
-  update: (updateInfo: SetupsUpdateInfo) => boolean,
+  update: (updateInfo: SetupsUpdateInfo, observerUpdateHints?: ObserversSetupUpdateHints) => boolean,
   getState: () => SetupsState,
   elements: SetupsElements,
   canceled: () => void,
@@ -125,10 +127,12 @@ export const createSetups = (
       _force: rawForce,
       _takeRecords,
       _cloneScrollbar,
+      _measureOverflow: rawMeasureOverflow,
     } = updateInfo;
 
     const _changedOptions = rawChangedOptions || {};
     const _force = !!rawForce || !cacheAndOptionsInitialized;
+    const _measureOverflow = !!rawMeasureOverflow;
     const baseUpdateInfoObj: SetupUpdateInfo = {
       _checkOption: createOptionCheck(options, _changedOptions, _force),
       _changedOptions,
@@ -152,6 +156,7 @@ export const createSetups = (
       assignDeep({}, baseUpdateInfoObj, {
         _observersState: observersSetupState,
         _observersUpdateHints: observersHints,
+        _measureOverflow,
       })
     );
 
@@ -159,13 +164,14 @@ export const createSetups = (
       assignDeep({}, baseUpdateInfoObj, {
         _observersUpdateHints: observersHints,
         _structureUpdateHints: structureHints,
+        _measureOverflow,
       })
     );
 
     const truthyObserversHints = updateHintsAreTruthy(observersHints);
     const truthyStructureHints = updateHintsAreTruthy(structureHints);
     const changed =
-      truthyObserversHints || truthyStructureHints || !isEmptyObject(_changedOptions) || _force;
+      truthyObserversHints || truthyStructureHints || !isEmptyObject(_changedOptions) || _force || _measureOverflow;
 
     cacheAndOptionsInitialized = true;
 

--- a/packages/overlayscrollbars/src/setups/structureSetup/structureSetup.ts
+++ b/packages/overlayscrollbars/src/setups/structureSetup/structureSetup.ts
@@ -45,6 +45,7 @@ export interface StructureSetupState {
 export interface StructureSetupUpdateInfo extends SetupUpdateInfo {
   _observersState: ObserversSetupState;
   _observersUpdateHints?: ObserversSetupUpdateHints;
+  _measureOverflow?: boolean;
 }
 
 export type StructureSetupUpdateHints = {

--- a/packages/overlayscrollbars/test/dom/overlayscrollbars.test.ts
+++ b/packages/overlayscrollbars/test/dom/overlayscrollbars.test.ts
@@ -542,6 +542,7 @@ describe('overlayscrollbars', () => {
       expect(osInstance.update()).toBe(false);
       expect(osInstance.update(false)).toBe(false);
       expect(osInstance.update(true)).toBe(true);
+      expect(osInstance.update({ measureOverflow: true })).toBe(true);
 
       // host mutation
       div.style.cursor = 'pointer';

--- a/website/mdx/README.mdx
+++ b/website/mdx/README.mdx
@@ -882,13 +882,20 @@ const osInstance = OverlayScrollbars(document.body, {});
   | name | `string` | The event name. |
   | listeners | `Function[]` | The functions to be removed. |
 
-  ### `update(force?): boolean`
+  ### `update(forceOrRequest?): boolean`
 
   Updates the instance.
 
   | parameter | type | description |
   | :--- | :--- | :--- |
+  | forceOrRequest | `boolean \| UpdateRequest \| undefined` |  Either a boolean indicating the `force` option below or an object below. |
+
+  When an object is passed you can use the following properties:
+
+  | property | type | description |
+  | :--- | :--- | :--- |
   | force | `boolean \| undefined` |  Whether the update should force the cache to be invalidated. |
+  | measureOverflow | `boolean \| undefined` |  Whether only overflow measurements should be force-updated, skipping expensive operations. |
 
   | returns | description |
   | :--- | :--- |
@@ -926,6 +933,11 @@ const osInstance = OverlayScrollbars(document.body, {});
 
   ```ts
   // A simplified version of the OverlayScrollbars TypeScript interface.
+  interface UpdateRequest {
+    force?: boolean;
+    measureOverflow?: boolean;
+  }
+
   interface OverlayScrollbars {
     // Get the current options of the instance.
     options(): Options;
@@ -945,7 +957,7 @@ const osInstance = OverlayScrollbars(document.body, {});
     off<N extends keyof EventListenerArgs>(name: N, listener: EventListener<N>[]): void;
 
     // Updates the instance.
-    update(force?: boolean): boolean;
+    update(forceOrRequest?: boolean | UpdateRequest): boolean;
 
     // Gets the instance's state.
     state(): State;


### PR DESCRIPTION
This is a follow-up for https://github.com/KingSora/OverlayScrollbars/issues/729.

`.update(true)` is very slow. From the performance tool in DevTools. the heavy path is: `update -> ... -> getElementOverflow -> getStyles -> "anonymousCallbackTo: from(styles).deduce" -> getCSSVal -> "Recalculate style"`.

To solve this, I introduced the option `.update({ measureOverflow: true })` to trigger an measurement update bypassing the heavy forced-update logic.