### PR TITLE
feat: allow users to force hide scrollbars

### DIFF
--- a/packages/overlayscrollbars/src/overlayscrollbars.ts
+++ b/packages/overlayscrollbars/src/overlayscrollbars.ts
@@ -309,6 +309,12 @@ export interface OverlayScrollbars {
   destroy(): void;
   /** Returns the instance of the passed plugin or `undefined` if no instance was found. */
   plugin<P extends InstancePlugin>(osPlugin: P): InferInstancePluginModuleInstance<P> | undefined;
+  /**
+   * Force-hides or un-hides all scrollbars, bypassing auto-show logic
+   * (pointer events, scroll events, etc.) while hidden.
+   * @param hidden Whether scrollbars should be force-hidden.
+   */
+  scrollbarsHidden(hidden: boolean): void;
 }
 
 export const OverlayScrollbars: OverlayScrollbarsStatic = (
@@ -346,7 +352,7 @@ export const OverlayScrollbars: OverlayScrollbarsStatic = (
       triggerInstanceEvent(name, args);
       triggerPluginEvent(name, args);
     };
-    const [setupsConstruct, setupsUpdate, setupsState, setupsElements, setupsCanceled] =
+    const [setupsConstruct, setupsUpdate, setupsState, setupsElements, setupsCanceled, setupsForceScrollbarsHidden] =
       createSetups(
         target,
         currentOptions,
@@ -510,6 +516,7 @@ export const OverlayScrollbars: OverlayScrollbarsStatic = (
         instancePluginModuleInstances[keys(plugin)[0]] as
           | InferInstancePluginModuleInstance<P>
           | undefined,
+      scrollbarsHidden: setupsForceScrollbarsHidden,
     };
 
     push(destroyFns, [setupsCanceled]);

--- a/packages/overlayscrollbars/src/setups/scrollbarsSetup/scrollbarsSetup.ts
+++ b/packages/overlayscrollbars/src/setups/scrollbarsSetup/scrollbarsSetup.ts
@@ -21,6 +21,7 @@ import {
   classNameScrollbarTrackInteractive,
   classNameScrollbarRtl,
   classNameScrollbarAutoHide,
+  classNameScrollbarTransitionless,
 } from '../../classnames';
 import { getEnvironment } from '../../environment';
 import {
@@ -53,6 +54,8 @@ export type ScrollbarsSetup = [
   ...Setup<ScrollbarsSetupUpdateInfo, ScrollbarsSetupState, void>,
   /** The elements created by the scrollbars setup. */
   ScrollbarsSetupElementsObj,
+  /** Force-hide or un-hide scrollbars, bypassing all auto-show logic. */
+  (hidden: boolean) => void,
 ];
 
 export const createScrollbarsSetup = (
@@ -70,6 +73,7 @@ export const createScrollbarsSetup = (
   let prevTheme: string | null | undefined;
   let instanceAutoHideSuspendScrollDestroyFn = noop;
   let instanceAutoHideDelay = 0;
+  let forcedHidden = false;
   const hoverablePointerTypes = ['mouse', 'pen'];
 
   // needed to not fire unnecessary operations for pointer events on ios safari which will cause side effects: https://github.com/KingSora/OverlayScrollbars/issues/560
@@ -102,6 +106,7 @@ export const createScrollbarsSetup = (
   } = elements;
   const manageScrollbarsAutoHide = (removeAutoHide: boolean, delayless?: boolean) => {
     clearAutoHideTimeout();
+    if (forcedHidden) return;
     if (removeAutoHide) {
       _scrollbarsAddRemoveClass(classNameScrollbarAutoHideHidden);
     } else {
@@ -114,6 +119,7 @@ export const createScrollbarsSetup = (
     }
   };
   const manageScrollbarsAutoHideInstantInteraction = () => {
+    if (forcedHidden) return;
     if (autoHideIsLeave ? !mouseInHost : !autoHideIsNever) {
       manageScrollbarsAutoHide(true);
       autoHideInstantInteractionTimeout(() => {
@@ -122,6 +128,7 @@ export const createScrollbarsSetup = (
     }
   };
   const manageAutoHideSuspension = (add: boolean) => {
+    if (forcedHidden && !add) return;
     _scrollbarsAddRemoveClass(classNameScrollbarAutoHide, add, true);
     _scrollbarsAddRemoveClass(classNameScrollbarAutoHide, add, false);
   };
@@ -169,6 +176,20 @@ export const createScrollbarsSetup = (
   const scrollbarsHidingPlugin = getStaticPluginModuleInstance<typeof ScrollbarsHidingPlugin>(
     scrollbarsHidingPluginName
   );
+
+  const _forceScrollbarsHidden = (hidden: boolean) => {
+    forcedHidden = hidden;
+    if (hidden) {
+      clearAutoHideTimeout();
+      clearAutoHideInstantInteractionTimeout();
+      _scrollbarsAddRemoveClass(classNameScrollbarAutoHide, true);
+      _scrollbarsAddRemoveClass(classNameScrollbarTransitionless, true);
+      _scrollbarsAddRemoveClass(classNameScrollbarAutoHideHidden, true);
+    } else {
+      _scrollbarsAddRemoveClass(classNameScrollbarAutoHideHidden, !autoHideIsNever);
+      _scrollbarsAddRemoveClass(classNameScrollbarTransitionless, false);
+    }
+  };
 
   return [
     () => bind(runEachAndClear, push(destroyFns, appendElements())),
@@ -297,8 +318,15 @@ export const createScrollbarsSetup = (
         _scrollbarsAddRemoveClass(classNameScrollbarUnusable, !_hasOverflow.y, false);
         _scrollbarsAddRemoveClass(classNameScrollbarRtl, _directionIsRTL && !_isBody);
       }
+
+      if (forcedHidden) {
+        _scrollbarsAddRemoveClass(classNameScrollbarAutoHide, true);
+        _scrollbarsAddRemoveClass(classNameScrollbarTransitionless, true);
+        _scrollbarsAddRemoveClass(classNameScrollbarAutoHideHidden, true);
+      }
     },
     {},
     elements,
+    _forceScrollbarsHidden,
   ];
 };

--- a/packages/overlayscrollbars/src/setups/setups.ts
+++ b/packages/overlayscrollbars/src/setups/setups.ts
@@ -73,6 +73,7 @@ export type Setups = [
   getState: () => SetupsState,
   elements: SetupsElements,
   canceled: () => void,
+  forceScrollbarsHidden: (hidden: boolean) => void,
 ];
 
 export const createSetups = (
@@ -99,7 +100,7 @@ export const createSetups = (
       update({}, observersUpdateHints);
     }
   );
-  const [scrollbarsSetupCreate, scrollbarsSetupUpdate, , scrollbarsSetupElements] =
+  const [scrollbarsSetupCreate, scrollbarsSetupUpdate, , scrollbarsSetupElements, scrollbarsForceHidden] =
     createScrollbarsSetup(
       target,
       options,
@@ -202,5 +203,6 @@ export const createSetups = (
       _scrollbarsSetupElements: scrollbarsSetupElements,
     },
     structureSetupCanceled,
+    scrollbarsForceHidden,
   ];
 };


### PR DESCRIPTION
Thanks for OverlayScrollbars, long time user here.. (I know OSS maintainers hear this a lot first hand, but still).

### Problem
In a split layout, I animate the chat column with transforms, then switch to flex. On desktop, with `scrollbars.autoHide: "move"`, the pointer often crosses the moving host during the animation. That drives the normal pointer/scroll auto-hide logic. When the animation ends and layout updates, the scrollbar can flash visible for a moment even if the cursor is no longer over the pane, it’s especially noticeable with the default opacity transition on `.os-scrollbar`.

https://github.com/user-attachments/assets/b4645b83-a887-469d-b18e-59aefeb74828

### Proposed Solution
Add an imperative instance method so embedders can temporarily force-hide scrollbars and ignore the usual auto-show sensor paths until they call the method again to restore normal behavior:

```diff
export interface OverlayScrollbars {
+  scrollbarsHidden(hidden: boolean): void;
}
```

When `hidden === true`, the instance should keep overlay scrollbars in the hidden state across internal `update()` cycles (e.g. after resize) so layout changes don’t briefly apply `os-scrollbar-visible` without the matching `auto-hide` hidden state.